### PR TITLE
Streaming Support for Prediction History Events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.acme</groupId>
@@ -55,6 +55,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/org/acme/spring/data/jpa/Prediction.java
+++ b/src/main/java/org/acme/spring/data/jpa/Prediction.java
@@ -1,0 +1,55 @@
+package org.acme.spring.data.jpa;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Prediction {
+
+	@Id
+    @GeneratedValue
+    private Long id;
+	private int homeScore;
+	private String homeTeam;
+	private String awayTeam;
+	private int awayScore;
+	
+	public String getWinningTeam() {
+		
+		// Todo: Handle Ties, but we punt for now.
+		return (homeScore >= awayScore) ? homeTeam : awayTeam;
+	}
+	
+	public Long getId() {
+		return id;
+	}
+	public void setId(Long id) {
+		this.id = id;
+	}
+	public int getHomeScore() {
+		return homeScore;
+	}
+	public void setHomeScore(int homeScore) {
+		this.homeScore = homeScore;
+	}
+	public String getHomeTeam() {
+		return homeTeam;
+	}
+	public void setHomeTeam(String homeTeam) {
+		this.homeTeam = homeTeam;
+	}
+	public String getAwayTeam() {
+		return awayTeam;
+	}
+	public void setAwayTeam(String awayTeam) {
+		this.awayTeam = awayTeam;
+	}
+	public int getAwayScore() {
+		return awayScore;
+	}
+	public void setAwayScore(int awayScore) {
+		this.awayScore = awayScore;
+	}
+	
+}

--- a/src/main/java/org/acme/spring/data/jpa/PredictionRepository.java
+++ b/src/main/java/org/acme/spring/data/jpa/PredictionRepository.java
@@ -1,0 +1,7 @@
+package org.acme.spring.data.jpa;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface PredictionRepository extends CrudRepository<Prediction, Long> {
+
+}

--- a/src/main/java/org/acme/spring/data/jpa/PredictionResource.java
+++ b/src/main/java/org/acme/spring/data/jpa/PredictionResource.java
@@ -1,0 +1,36 @@
+package org.acme.spring.data.jpa;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.reactive.messaging.Channel;
+import org.jboss.resteasy.annotations.SseElementType;
+import org.reactivestreams.Publisher;
+
+@Path("/predictions")
+public class PredictionResource {
+
+	@Inject
+	PredictionRepository repo;
+	
+	@Inject
+	@Channel("predictions-stream") Publisher<Prediction> predictions;
+	
+	@GET
+	@Produces("application/json")
+	public Iterable<Prediction> getPredictionHistory() {
+		return repo.findAll();
+	}
+	
+	@GET
+	@Path("/stream")
+	@Produces(MediaType.SERVER_SENT_EVENTS)
+	@SseElementType("application/json")
+	public Publisher<Prediction> stream() {
+		return predictions;
+	}
+	
+}

--- a/src/main/java/org/acme/spring/data/messaging/MatchResult.java
+++ b/src/main/java/org/acme/spring/data/messaging/MatchResult.java
@@ -1,0 +1,25 @@
+package org.acme.spring.data.messaging;
+
+public class MatchResult {
+    public String home_team;
+    public String away_team;
+    public Integer home_score;
+    public Integer away_score;
+
+    public MatchResult(String home_team, String away_team, Integer home_score, Integer away_score) {
+        this.home_team = home_team;
+        this.away_team = away_team;
+        this.home_score = home_score;
+        this.away_score = away_score;
+    }
+
+    public MatchResult() {
+    }
+
+	@Override
+	public String toString() {
+		return "MatchResult [home_team=" + home_team + ", away_team=" + away_team + ", home_score=" + home_score
+				+ ", away_score=" + away_score + "]";
+	}
+    
+}

--- a/src/main/java/org/acme/spring/data/messaging/PredictionHandler.java
+++ b/src/main/java/org/acme/spring/data/messaging/PredictionHandler.java
@@ -1,0 +1,38 @@
+package org.acme.spring.data.messaging;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.acme.spring.data.jpa.Prediction;
+import org.acme.spring.data.jpa.PredictionRepository;
+import org.eclipse.microprofile.reactive.messaging.Incoming;
+import org.eclipse.microprofile.reactive.messaging.Outgoing;
+import org.jboss.logging.Logger;
+
+import io.smallrye.reactive.messaging.annotations.Broadcast;
+
+@ApplicationScoped
+public class PredictionHandler {
+
+	private static Logger logger = Logger.getLogger(PredictionHandler.class);
+	
+	@Inject
+	PredictionRepository repository;
+	
+	@Incoming("predictions")
+	@Outgoing("predictions-stream")
+	@Broadcast
+	public Prediction process(MatchResult event) {
+		
+		logger.debug("Receiving Event: " + event.toString());
+		
+		Prediction newPrediction = new Prediction();
+		newPrediction.setAwayScore(event.away_score);
+		newPrediction.setAwayTeam(event.away_team);
+		newPrediction.setHomeScore(event.home_score);
+		newPrediction.setHomeTeam(event.home_team);
+		
+		return this.repository.save(newPrediction);
+	}
+	
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,10 @@ quarkus.datasource.jdbc.min-size=2
 
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.sql-load-script=import.sql
+
+mp.messaging.incoming.predictions.connector=smallrye-kafka
+mp.messaging.incoming.predictions.bootstrap.servers=kafka-kafka-bootstrap:9092
+mp.messaging.incoming.predictions.topic=predictions
+mp.messaging.incoming.predictions.value.deserializer=io.vertx.kafka.client.serialization.JsonObjectDeserializer
+
+mp.messaging.outgoing.predictions-stream.value.serializer=io.vertx.kafka.client.serialization.JsonObjectSerializer


### PR DESCRIPTION
I added several things here as well. This has not been tested / deployed yet. 

The changes include: 
* New domain model called Prediction
* PredictionEventHandler that processes events from the main bookie API
* Expose endpoints for getting all predictions saved (pull)
* exposed endpoint for exposing a stream (push)

Please, Please deploy and test with the other branch https://github.com/redhat-hackfest-bookie/alexa-bookie/pull/1